### PR TITLE
POC for synchronization with wei/pull app

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,0 +1,14 @@
+version: "1"
+rules:
+  - base: master
+    upstream: UncleGoogle:master
+    mergeMethod: none  # Optional, one of [none, merge, squash, rebase, hardreset], Default: none.
+    mergeUnstable: false    # Optional, merge pull request even when the mergeable_state is not clean. Default: false
+    # assignees:              # Optional
+    reviewers:              # Optional
+      - urwrstkn8mare
+      - AndrewDWhite
+    conflictReviewers:      # Optional, on merge conflict assign a reviewer
+      - UncleGoogle
+label: ":arrow_heading_down: pull"  # Optional
+conflictLabel: "merge-conflict"     # Optional, on merge conflict assign a custom label, Default: merge-conflict

--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -10,5 +10,5 @@ rules:
       - AndrewDWhite
     conflictReviewers:      # Optional, on merge conflict assign a reviewer
       - UncleGoogle
-label: ":arrow_heading_down: pull"  # Optional
+label: ":arrow_heading_down: sync"  # Optional
 conflictLabel: "merge-conflict"     # Optional, on merge conflict assign a custom label, Default: merge-conflict


### PR DESCRIPTION
Followed by instructions in https://github.com/wei/pull

I'm going to check how it works. In the future I'm going to create script to standardize the whole process.

I've already change default branch to `synchronization-settings`. Actually this branch could be completely empty with just a readme explaining what this repo is. So I'll keep this in mind when doing some initialization scripts for further forks.

`mergeMethod: none` - - is it going to create PR instead of merging automatically? I hope so.

----

I like the fact that we can have this settings per repo - so there can be a differnet set of reviewers for different repos to spread responsibility. For now in the script I would add set of all org members minus original repo owner

Relates to https://github.com/GOG-Nebula/.github/issues/11