### PR TITLE
Update sync.yaml

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -1,7 +1,7 @@
 name: sync-upstream
 on:
   schedule:
-    - cron: '23 * * * *'
+    - cron: '0 12,00 * * *'
   workflow_dispatch:
 jobs:
   sync:


### PR DESCRIPTION
Due to limits github rejects some runs: https://github.com/GOG-Nebula/galaxy-integration-humblebundle/actions/runs/2802014010

> [sync](https://github.com/GOG-Nebula/galaxy-integration-humblebundle/runs/7687039769?check_suite_focus=true#step:2:57)
HttpError: You have exceeded a secondary rate limit. Please wait a few minutes before you try again.

Twice a day should be more than enough